### PR TITLE
Fix calendar list range controls and legend labels (#149, #150)

### DIFF
--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -939,7 +939,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         </div>
         <div className="calendar-ux-toolbar">
           {this.state.currentCalendarView === "listWeek" && (
-            <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
+            <div className="calendar-quick-filters fc" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
                 className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -129,29 +129,10 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           break;
         case "all":
         default:
-          if (this.state.currentCalendarView.startsWith("list")) {
-            calendarApi.changeView("listWeek", moment().toDate());
-          }
+          calendarApi.changeView("listYear", moment().startOf("year").toDate());
           break;
       }
     });
-  };
-
-  applyCalendarQuickFilter = (item: SummitCalendarItem): boolean => {
-    const itemStart = moment(item.StartTime);
-
-    switch (this.state.calendarQuickFilter) {
-      case "next7days": {
-        const now = moment();
-        const horizon = moment().add(7, "days").endOf("day");
-        return itemStart.isBetween(now, horizon, undefined, "[]");
-      }
-      case "thisMonth":
-        return itemStart.isSame(moment(), "month");
-      case "all":
-      default:
-        return true;
-    }
   };
 
   shouldIgnoreSchedulerShortcut = (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
@@ -943,14 +924,9 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         item,
       },
     }));
-    // Only apply quick filter when in list view
     const isListView = this.state.currentCalendarView.startsWith("list");
-    const filteredItems = isListView
-      ? this.state.items.filter((item) => this.applyCalendarQuickFilter(item))
-      : this.state.items;
-    const events = isListView
-      ? allEvents.filter((event) => this.applyCalendarQuickFilter(event.extendedProps.item))
-      : allEvents;
+    const filteredItems = this.state.items;
+    const events = allEvents;
 
     return (
       <div id="scheduler" style={{ width: "100%", height: "100%" }} onKeyDown={this.handleSchedulerKeyDown} tabIndex={0} data-calendar-shortcuts="new-event">

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -51,7 +51,6 @@ interface SummitCalendarState {
   editorValidationErrors: Record<string, string>;
   editorSoftConflictWarnings: string[];
   currentCalendarView: string;
-  calendarRangeContextLabel: string;
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
@@ -76,7 +75,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       editorValidationErrors: {},
       editorSoftConflictWarnings: [],
       currentCalendarView: this.loadPersistedCalendarView(),
-      calendarRangeContextLabel: "Current range: loading...",
     };
     this.handleInputChange = this.handleInputChange.bind(this);
   }
@@ -241,10 +239,8 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
   handleDatesSet = (args: DatesSetArg) => {
     const startDate = moment(args.start).format("YYYY-MM-DDTHH:mm:ss");
     const endDate = moment(args.end).format("YYYY-MM-DDTHH:mm:ss");
-    const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
-
     this.persistCalendarView(args.view.type);
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel }, () => {
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type }, () => {
       this.fetchData(startDate, endDate);
     });
   };
@@ -907,10 +903,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-
-          <div className="calendar-range-context" data-calendar-range-context="visible">
-            {this.state.calendarRangeContextLabel}
-          </div>
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -26,7 +26,6 @@ import { DropDownListComponent } from "@/components/SimpleDropdown";
 import { DialogComponent, DialogUtility } from "@/components/DialogComponent";
 
 const SUMMIT_CALENDAR_VIEW_STORAGE_KEY = "summit.calendar.currentView";
-type CalendarQuickFilter = "all" | "next7days" | "thisMonth";
 
 interface SummitCalendarProps {
   items: SummitCalendarItem[];
@@ -52,13 +51,10 @@ interface SummitCalendarState {
   editorValidationErrors: Record<string, string>;
   editorSoftConflictWarnings: string[];
   currentCalendarView: string;
-  calendarQuickFilter: CalendarQuickFilter;
   calendarRangeContextLabel: string;
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
-  private calendarRef = React.createRef<FullCalendar>();
-
   constructor(props: SummitCalendarProps) {
     super(props);
     this.state = {
@@ -80,7 +76,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       editorValidationErrors: {},
       editorSoftConflictWarnings: [],
       currentCalendarView: this.loadPersistedCalendarView(),
-      calendarQuickFilter: "all",
       calendarRangeContextLabel: "Current range: loading...",
     };
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -111,28 +106,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     } catch {
       // Non-blocking persistence: ignore storage failures.
     }
-  };
-
-  setCalendarQuickFilter = (calendarQuickFilter: CalendarQuickFilter) => {
-    this.setState({ calendarQuickFilter }, () => {
-      const calendarApi = this.calendarRef.current?.getApi();
-      if (!calendarApi) {
-        return;
-      }
-
-      switch (calendarQuickFilter) {
-        case "next7days":
-          calendarApi.changeView("listWeek", moment().toDate());
-          break;
-        case "thisMonth":
-          calendarApi.changeView("listMonth", moment().startOf("month").toDate());
-          break;
-        case "all":
-        default:
-          calendarApi.changeView("listYear", moment().startOf("year").toDate());
-          break;
-      }
-    });
   };
 
   shouldIgnoreSchedulerShortcut = (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
@@ -271,9 +244,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
 
     this.persistCalendarView(args.view.type);
-    const preserveListFilter = this.state.currentCalendarView.startsWith("list") && args.view.type.startsWith("list");
-    const calendarQuickFilter = preserveListFilter ? this.state.calendarQuickFilter : "all";
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel, calendarQuickFilter }, () => {
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel }, () => {
       this.fetchData(startDate, endDate);
     });
   };
@@ -924,7 +895,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         item,
       },
     }));
-    const isListView = this.state.currentCalendarView.startsWith("list");
+
     const filteredItems = this.state.items;
     const events = allEvents;
 
@@ -936,51 +907,25 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          {isListView && (
-            <div className="calendar-quick-filters fc fc-button-group" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
-              <button
-                type="button"
-                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}
-                data-calendar-quick-filter="all"
-                aria-pressed={this.state.calendarQuickFilter === "all"}
-                onClick={() => this.setCalendarQuickFilter("all")}
-              >
-                All
-              </button>
-              <button
-                type="button"
-                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "next7days" ? "fc-button-active" : ""}`}
-                data-calendar-quick-filter="next7days"
-                aria-pressed={this.state.calendarQuickFilter === "next7days"}
-                onClick={() => this.setCalendarQuickFilter("next7days")}
-              >
-                Week
-              </button>
-              <button
-                type="button"
-                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "thisMonth" ? "fc-button-active" : ""}`}
-                data-calendar-quick-filter="thisMonth"
-                aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
-                onClick={() => this.setCalendarQuickFilter("thisMonth")}
-              >
-                Month
-              </button>
-            </div>
-          )}
+
           <div className="calendar-range-context" data-calendar-range-context="visible">
             {this.state.calendarRangeContextLabel}
           </div>
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar
-          ref={this.calendarRef}
           plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
           // Legacy contract marker: initialView="dayGridMonth"
           initialView={this.state.currentCalendarView}
+          buttonText={{
+            listYear: "Year",
+            listMonth: "Month",
+            listWeek: "Week",
+          }}
           headerToolbar={{
-            left: "prev,next today",
+            left: "prev,next today listYear,listWeek,listMonth",
             center: "title",
-            right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
+            right: "dayGridMonth,timeGridWeek,timeGridDay",
           }}
           events={events}
           selectable={true}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -954,7 +954,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
                 aria-pressed={this.state.calendarQuickFilter === "next7days"}
                 onClick={() => this.setCalendarQuickFilter("next7days")}
               >
-                Next 7 days
+                Week
               </button>
               <button
                 type="button"
@@ -963,7 +963,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
                 aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
                 onClick={() => this.setCalendarQuickFilter("thisMonth")}
               >
-                This month
+                Month
               </button>
             </div>
           )}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -919,8 +919,14 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         item,
       },
     }));
-    const filteredItems = this.state.items.filter((item) => this.applyCalendarQuickFilter(item));
-    const events = allEvents.filter((event) => this.applyCalendarQuickFilter(event.extendedProps.item));
+    // Only apply quick filter when in list view
+    const isListView = this.state.currentCalendarView === "listWeek";
+    const filteredItems = isListView
+      ? this.state.items.filter((item) => this.applyCalendarQuickFilter(item))
+      : this.state.items;
+    const events = isListView
+      ? allEvents.filter((event) => this.applyCalendarQuickFilter(event.extendedProps.item))
+      : allEvents;
 
     return (
       <div id="scheduler" style={{ width: "100%", height: "100%" }} onKeyDown={this.handleSchedulerKeyDown} tabIndex={0} data-calendar-shortcuts="new-event">
@@ -930,17 +936,19 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
-            <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="all" onClick={() => this.setCalendarQuickFilter("all")}>
-              All
-            </button>
-            <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="next7days" onClick={() => this.setCalendarQuickFilter("next7days")}>
-              Next 7 days
-            </button>
-            <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="thisMonth" onClick={() => this.setCalendarQuickFilter("thisMonth")}>
-              This month
-            </button>
-          </div>
+          {this.state.currentCalendarView === "listWeek" && (
+            <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
+              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="all" onClick={() => this.setCalendarQuickFilter("all")}>
+                All
+              </button>
+              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="next7days" onClick={() => this.setCalendarQuickFilter("next7days")}>
+                Next 7 days
+              </button>
+              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="thisMonth" onClick={() => this.setCalendarQuickFilter("thisMonth")}>
+                This month
+              </button>
+            </div>
+          )}
           <div className="calendar-range-context" data-calendar-range-context="visible">
             {this.state.calendarRangeContextLabel}
           </div>

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -57,6 +57,8 @@ interface SummitCalendarState {
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
+  private calendarRef = React.createRef<FullCalendar>();
+
   constructor(props: SummitCalendarProps) {
     super(props);
     this.state = {
@@ -112,7 +114,27 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
   };
 
   setCalendarQuickFilter = (calendarQuickFilter: CalendarQuickFilter) => {
-    this.setState({ calendarQuickFilter });
+    this.setState({ calendarQuickFilter }, () => {
+      const calendarApi = this.calendarRef.current?.getApi();
+      if (!calendarApi) {
+        return;
+      }
+
+      switch (calendarQuickFilter) {
+        case "next7days":
+          calendarApi.changeView("listWeek", moment().toDate());
+          break;
+        case "thisMonth":
+          calendarApi.changeView("listMonth", moment().startOf("month").toDate());
+          break;
+        case "all":
+        default:
+          if (this.state.currentCalendarView.startsWith("list")) {
+            calendarApi.changeView("listWeek", moment().toDate());
+          }
+          break;
+      }
+    });
   };
 
   applyCalendarQuickFilter = (item: SummitCalendarItem): boolean => {
@@ -268,7 +290,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
 
     this.persistCalendarView(args.view.type);
-    const preserveListFilter = this.state.currentCalendarView === "listWeek" && args.view.type === "listWeek";
+    const preserveListFilter = this.state.currentCalendarView.startsWith("list") && args.view.type.startsWith("list");
     const calendarQuickFilter = preserveListFilter ? this.state.calendarQuickFilter : "all";
     this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel, calendarQuickFilter }, () => {
       this.fetchData(startDate, endDate);
@@ -922,7 +944,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       },
     }));
     // Only apply quick filter when in list view
-    const isListView = this.state.currentCalendarView === "listWeek";
+    const isListView = this.state.currentCalendarView.startsWith("list");
     const filteredItems = isListView
       ? this.state.items.filter((item) => this.applyCalendarQuickFilter(item))
       : this.state.items;
@@ -938,7 +960,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          {this.state.currentCalendarView === "listWeek" && (
+          {isListView && (
             <div className="calendar-quick-filters fc fc-button-group" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
@@ -975,6 +997,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar
+          ref={this.calendarRef}
           plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
           // Legacy contract marker: initialView="dayGridMonth"
           initialView={this.state.currentCalendarView}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -942,7 +942,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
             <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
-                className={`summit-button ${this.state.calendarQuickFilter === "all" ? "summit-button-primary" : "summit-button-secondary"}`}
+                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}
                 data-calendar-quick-filter="all"
                 aria-pressed={this.state.calendarQuickFilter === "all"}
                 onClick={() => this.setCalendarQuickFilter("all")}
@@ -951,7 +951,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
               </button>
               <button
                 type="button"
-                className={`summit-button ${this.state.calendarQuickFilter === "next7days" ? "summit-button-primary" : "summit-button-secondary"}`}
+                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "next7days" ? "fc-button-active" : ""}`}
                 data-calendar-quick-filter="next7days"
                 aria-pressed={this.state.calendarQuickFilter === "next7days"}
                 onClick={() => this.setCalendarQuickFilter("next7days")}
@@ -960,7 +960,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
               </button>
               <button
                 type="button"
-                className={`summit-button ${this.state.calendarQuickFilter === "thisMonth" ? "summit-button-primary" : "summit-button-secondary"}`}
+                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "thisMonth" ? "fc-button-active" : ""}`}
                 data-calendar-quick-filter="thisMonth"
                 aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
                 onClick={() => this.setCalendarQuickFilter("thisMonth")}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -939,7 +939,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         </div>
         <div className="calendar-ux-toolbar">
           {this.state.currentCalendarView === "listWeek" && (
-            <div className="calendar-quick-filters fc" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
+            <div className="calendar-quick-filters fc fc-button-group" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
                 className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -268,7 +268,9 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
 
     this.persistCalendarView(args.view.type);
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel }, () => {
+    const preserveListFilter = this.state.currentCalendarView === "listWeek" && args.view.type === "listWeek";
+    const calendarQuickFilter = preserveListFilter ? this.state.calendarQuickFilter : "all";
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel, calendarQuickFilter }, () => {
       this.fetchData(startDate, endDate);
     });
   };
@@ -938,13 +940,31 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         <div className="calendar-ux-toolbar">
           {this.state.currentCalendarView === "listWeek" && (
             <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
-              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="all" onClick={() => this.setCalendarQuickFilter("all")}>
+              <button
+                type="button"
+                className={`summit-button ${this.state.calendarQuickFilter === "all" ? "summit-button-primary" : "summit-button-secondary"}`}
+                data-calendar-quick-filter="all"
+                aria-pressed={this.state.calendarQuickFilter === "all"}
+                onClick={() => this.setCalendarQuickFilter("all")}
+              >
                 All
               </button>
-              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="next7days" onClick={() => this.setCalendarQuickFilter("next7days")}>
+              <button
+                type="button"
+                className={`summit-button ${this.state.calendarQuickFilter === "next7days" ? "summit-button-primary" : "summit-button-secondary"}`}
+                data-calendar-quick-filter="next7days"
+                aria-pressed={this.state.calendarQuickFilter === "next7days"}
+                onClick={() => this.setCalendarQuickFilter("next7days")}
+              >
                 Next 7 days
               </button>
-              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="thisMonth" onClick={() => this.setCalendarQuickFilter("thisMonth")}>
+              <button
+                type="button"
+                className={`summit-button ${this.state.calendarQuickFilter === "thisMonth" ? "summit-button-primary" : "summit-button-secondary"}`}
+                data-calendar-quick-filter="thisMonth"
+                aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
+                onClick={() => this.setCalendarQuickFilter("thisMonth")}
+              >
                 This month
               </button>
             </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -206,11 +206,18 @@
   gap: 8px;
 }
 
+.calendar-quick-filters.fc {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
 .calendar-quick-filters.fc .fc-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: auto;
+  white-space: nowrap;
   margin: 0;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -207,18 +207,22 @@
 }
 
 .calendar-quick-filters.fc {
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: nowrap;
+  display: inline-flex !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
+  flex-direction: row !important;
 }
 
 .calendar-quick-filters.fc .fc-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: auto;
-  white-space: nowrap;
-  margin: 0;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: auto !important;
+  min-width: unset !important;
+  white-space: nowrap !important;
+  margin: 0 !important;
+  float: none !important;
+  flex: 0 0 auto !important;
 }
 
 .calendar-range-context {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -201,30 +201,6 @@
   margin: var(--summit-space-md) 0;
 }
 
-.calendar-quick-filters {
-  display: inline-flex;
-  gap: 8px;
-}
-
-.calendar-quick-filters.fc {
-  display: inline-flex !important;
-  align-items: center !important;
-  flex-wrap: nowrap !important;
-  flex-direction: row !important;
-}
-
-.calendar-quick-filters.fc .fc-button {
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  width: auto !important;
-  min-width: unset !important;
-  white-space: nowrap !important;
-  margin: 0 !important;
-  float: none !important;
-  flex: 0 0 auto !important;
-}
-
 .calendar-range-context {
   font-weight: var(--summit-font-weight-semibold);
   color: var(--summit-color-bg-primary);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -206,6 +206,14 @@
   gap: 8px;
 }
 
+.calendar-quick-filters.fc .fc-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  margin: 0;
+}
+
 .calendar-range-context {
   font-weight: var(--summit-font-weight-semibold);
   color: var(--summit-color-bg-primary);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -201,11 +201,6 @@
   margin: var(--summit-space-md) 0;
 }
 
-.calendar-range-context {
-  font-weight: var(--summit-font-weight-semibold);
-  color: var(--summit-color-bg-primary);
-}
-
 .calendar-legend {
   display: inline-flex;
   gap: 10px;


### PR DESCRIPTION
Closes #149 and #150
Replaced custom list filter buttons with native FullCalendar header buttons (Year/Week/Month)
Ensured range controls operate via view changes (not event filtering), fixing navigation behavior
Removed redundant current-range text
Updated legend to show calendar/group names instead of "Event colour N"