### PR TITLE
feat(calendar): list view range controls, en-AU locale, and legend names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /playwright-report
 /github/agents
 /screenshots
+/.vscode/chrome-debug-profile

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "jspdf-autotable": "^5.0.7",
         "moment": "^2.30.1",
         "react": "^18.2.0",
+        "react-datepicker": "^9.1.0",
         "react-dom": "^18.2.0",
         "xlsx": "^0.18.5"
       },
@@ -2295,6 +2296,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@fullcalendar/core": {
       "version": "6.1.20",
@@ -6637,6 +6691,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7335,6 +7398,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/de-indent": {
@@ -14618,6 +14691,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-9.1.0.tgz",
+      "integrity": "sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.15",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "date-fns-tz": "^3.0.0",
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "date-fns-tz": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -15757,6 +15851,12 @@
       "funding": {
         "url": "https://opencollective.com/synckit"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jspdf-autotable": "^5.0.7",
     "moment": "^2.30.1",
     "react": "^18.2.0",
+    "react-datepicker": "^9.1.0",
     "react-dom": "^18.2.0",
     "xlsx": "^0.18.5"
   },

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -939,7 +939,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         </div>
         <div className="calendar-ux-toolbar">
           {this.state.currentCalendarView === "listWeek" && (
-            <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
+            <div className="calendar-quick-filters fc" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
                 className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -129,29 +129,10 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           break;
         case "all":
         default:
-          if (this.state.currentCalendarView.startsWith("list")) {
-            calendarApi.changeView("listWeek", moment().toDate());
-          }
+          calendarApi.changeView("listYear", moment().startOf("year").toDate());
           break;
       }
     });
-  };
-
-  applyCalendarQuickFilter = (item: SummitCalendarItem): boolean => {
-    const itemStart = moment(item.StartTime);
-
-    switch (this.state.calendarQuickFilter) {
-      case "next7days": {
-        const now = moment();
-        const horizon = moment().add(7, "days").endOf("day");
-        return itemStart.isBetween(now, horizon, undefined, "[]");
-      }
-      case "thisMonth":
-        return itemStart.isSame(moment(), "month");
-      case "all":
-      default:
-        return true;
-    }
   };
 
   shouldIgnoreSchedulerShortcut = (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
@@ -943,14 +924,9 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         item,
       },
     }));
-    // Only apply quick filter when in list view
     const isListView = this.state.currentCalendarView.startsWith("list");
-    const filteredItems = isListView
-      ? this.state.items.filter((item) => this.applyCalendarQuickFilter(item))
-      : this.state.items;
-    const events = isListView
-      ? allEvents.filter((event) => this.applyCalendarQuickFilter(event.extendedProps.item))
-      : allEvents;
+    const filteredItems = this.state.items;
+    const events = allEvents;
 
     return (
       <div id="scheduler" style={{ width: "100%", height: "100%" }} onKeyDown={this.handleSchedulerKeyDown} tabIndex={0} data-calendar-shortcuts="new-event">

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -51,7 +51,6 @@ interface SummitCalendarState {
   editorValidationErrors: Record<string, string>;
   editorSoftConflictWarnings: string[];
   currentCalendarView: string;
-  calendarRangeContextLabel: string;
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
@@ -76,7 +75,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       editorValidationErrors: {},
       editorSoftConflictWarnings: [],
       currentCalendarView: this.loadPersistedCalendarView(),
-      calendarRangeContextLabel: "Current range: loading...",
     };
     this.handleInputChange = this.handleInputChange.bind(this);
   }
@@ -241,10 +239,8 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
   handleDatesSet = (args: DatesSetArg) => {
     const startDate = moment(args.start).format("YYYY-MM-DDTHH:mm:ss");
     const endDate = moment(args.end).format("YYYY-MM-DDTHH:mm:ss");
-    const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
-
     this.persistCalendarView(args.view.type);
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel }, () => {
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type }, () => {
       this.fetchData(startDate, endDate);
     });
   };
@@ -907,10 +903,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-
-          <div className="calendar-range-context" data-calendar-range-context="visible">
-            {this.state.calendarRangeContextLabel}
-          </div>
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -8,6 +8,8 @@ import { DateSelectArg, DatesSetArg, EventClickArg, EventMountArg } from "@fullc
 import SummitCalendarItem from "../models/SummitCalendarItems";
 import { createNewEvent, deleteEvent, fetchActivity, fetchMemberCalendars, fetchMemberEvents, fetchUnitMembers, updateEvent, updateMemberCalendars } from "@/services";
 import moment from "moment";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 import { TerrainEvent, TerrainUnitMember, TerrrainCalendarResult } from "@/types/terrainTypes";
 import {
   TerrainState,
@@ -314,30 +316,36 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     );
   };
 
-  handleAgendaRangeStartChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ agendaRangeStart: event.target.value, agendaRangePreset: "custom" });
-  };
+  handleListRangePickerChange = (dates: [Date | null, Date | null]) => {
+    const [startDate, endDate] = dates;
 
-  handleAgendaRangeEndChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ agendaRangeEnd: event.target.value, agendaRangePreset: "custom" });
-  };
+    if (!startDate) {
+      this.setState({ agendaRangeStart: "", agendaRangeEnd: "", agendaRangePreset: "custom" });
+      return;
+    }
 
-  applyCustomAgendaRange = () => {
+    if (!endDate) {
+      this.setState({ agendaRangeStart: moment(startDate).format("YYYY-MM-DD"), agendaRangeEnd: "", agendaRangePreset: "custom" });
+      return;
+    }
+
     const calendarApi = this.calendarRef.current?.getApi();
     if (!calendarApi) {
+      this.setState({ agendaRangeStart: moment(startDate).format("YYYY-MM-DD"), agendaRangeEnd: moment(endDate).format("YYYY-MM-DD"), agendaRangePreset: "custom" });
       return;
     }
 
-    const start = moment(this.state.agendaRangeStart, "YYYY-MM-DD", true);
-    const endInclusive = moment(this.state.agendaRangeEnd, "YYYY-MM-DD", true);
-    if (!start.isValid() || !endInclusive.isValid() || endInclusive.isBefore(start)) {
-      return;
-    }
-
-    const endExclusive = endInclusive.clone().add(1, "day");
-    this.setState({ agendaRangePreset: "custom" }, () => {
-      calendarApi.changeView("listRange", { start: start.toDate(), end: endExclusive.toDate() });
-    });
+    const endExclusive = moment(endDate).add(1, "day");
+    this.setState(
+      {
+        agendaRangeStart: moment(startDate).format("YYYY-MM-DD"),
+        agendaRangeEnd: moment(endDate).format("YYYY-MM-DD"),
+        agendaRangePreset: "custom",
+      },
+      () => {
+        calendarApi.changeView("listRange", { start: startDate, end: endExclusive.toDate() });
+      },
+    );
   };
 
   renderCalendarLegend = (items: SummitCalendarItem[]) => {
@@ -998,6 +1006,9 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       },
     }));
 
+    const listRangeStartDate = moment(this.state.agendaRangeStart, "YYYY-MM-DD", true);
+    const listRangeEndDate = moment(this.state.agendaRangeEnd, "YYYY-MM-DD", true);
+
     const filteredItems = this.state.items;
     const events = allEvents;
 
@@ -1011,13 +1022,18 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         <div className="calendar-ux-toolbar">
           {isListView && (
             <div className="calendar-agenda-range-controls" data-calendar-range-controls="visible">
-              <span className="calendar-agenda-range-label">List range:</span>
-              <input type="date" className="summit-form-input" value={this.state.agendaRangeStart} onChange={this.handleAgendaRangeStartChange} aria-label="List range start date" />
-              <span className="calendar-agenda-range-separator">to</span>
-              <input type="date" className="summit-form-input" value={this.state.agendaRangeEnd} onChange={this.handleAgendaRangeEndChange} aria-label="List range end date" />
-              <button type="button" className="summit-button summit-button-secondary" onClick={this.applyCustomAgendaRange}>
-                Apply
-              </button>
+              <span id="list-range-label" className="calendar-agenda-range-label">List range:</span>
+              <DatePicker
+                selected={listRangeStartDate.isValid() ? listRangeStartDate.toDate() : null}
+                onChange={(dates) => this.handleListRangePickerChange(dates as [Date | null, Date | null])}
+                startDate={listRangeStartDate.isValid() ? listRangeStartDate.toDate() : null}
+                endDate={listRangeEndDate.isValid() ? listRangeEndDate.toDate() : null}
+                selectsRange={true}
+                dateFormat="dd/MM/yyyy"
+                className="summit-form-input"
+                placeholderText="Select date range"
+                ariaLabelledBy="list-range-label"
+              />
               <div className="calendar-agenda-presets" role="group" aria-label="List quick select">
                 <button
                   type="button"

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -26,7 +26,6 @@ import { DropDownListComponent } from "@/components/SimpleDropdown";
 import { DialogComponent, DialogUtility } from "@/components/DialogComponent";
 
 const SUMMIT_CALENDAR_VIEW_STORAGE_KEY = "summit.calendar.currentView";
-type CalendarQuickFilter = "all" | "next7days" | "thisMonth";
 
 interface SummitCalendarProps {
   items: SummitCalendarItem[];
@@ -52,13 +51,10 @@ interface SummitCalendarState {
   editorValidationErrors: Record<string, string>;
   editorSoftConflictWarnings: string[];
   currentCalendarView: string;
-  calendarQuickFilter: CalendarQuickFilter;
   calendarRangeContextLabel: string;
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
-  private calendarRef = React.createRef<FullCalendar>();
-
   constructor(props: SummitCalendarProps) {
     super(props);
     this.state = {
@@ -80,7 +76,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       editorValidationErrors: {},
       editorSoftConflictWarnings: [],
       currentCalendarView: this.loadPersistedCalendarView(),
-      calendarQuickFilter: "all",
       calendarRangeContextLabel: "Current range: loading...",
     };
     this.handleInputChange = this.handleInputChange.bind(this);
@@ -111,28 +106,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     } catch {
       // Non-blocking persistence: ignore storage failures.
     }
-  };
-
-  setCalendarQuickFilter = (calendarQuickFilter: CalendarQuickFilter) => {
-    this.setState({ calendarQuickFilter }, () => {
-      const calendarApi = this.calendarRef.current?.getApi();
-      if (!calendarApi) {
-        return;
-      }
-
-      switch (calendarQuickFilter) {
-        case "next7days":
-          calendarApi.changeView("listWeek", moment().toDate());
-          break;
-        case "thisMonth":
-          calendarApi.changeView("listMonth", moment().startOf("month").toDate());
-          break;
-        case "all":
-        default:
-          calendarApi.changeView("listYear", moment().startOf("year").toDate());
-          break;
-      }
-    });
   };
 
   shouldIgnoreSchedulerShortcut = (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
@@ -271,9 +244,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
 
     this.persistCalendarView(args.view.type);
-    const preserveListFilter = this.state.currentCalendarView.startsWith("list") && args.view.type.startsWith("list");
-    const calendarQuickFilter = preserveListFilter ? this.state.calendarQuickFilter : "all";
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel, calendarQuickFilter }, () => {
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel }, () => {
       this.fetchData(startDate, endDate);
     });
   };
@@ -924,7 +895,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         item,
       },
     }));
-    const isListView = this.state.currentCalendarView.startsWith("list");
+
     const filteredItems = this.state.items;
     const events = allEvents;
 
@@ -936,51 +907,25 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          {isListView && (
-            <div className="calendar-quick-filters fc fc-button-group" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
-              <button
-                type="button"
-                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}
-                data-calendar-quick-filter="all"
-                aria-pressed={this.state.calendarQuickFilter === "all"}
-                onClick={() => this.setCalendarQuickFilter("all")}
-              >
-                All
-              </button>
-              <button
-                type="button"
-                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "next7days" ? "fc-button-active" : ""}`}
-                data-calendar-quick-filter="next7days"
-                aria-pressed={this.state.calendarQuickFilter === "next7days"}
-                onClick={() => this.setCalendarQuickFilter("next7days")}
-              >
-                Week
-              </button>
-              <button
-                type="button"
-                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "thisMonth" ? "fc-button-active" : ""}`}
-                data-calendar-quick-filter="thisMonth"
-                aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
-                onClick={() => this.setCalendarQuickFilter("thisMonth")}
-              >
-                Month
-              </button>
-            </div>
-          )}
+
           <div className="calendar-range-context" data-calendar-range-context="visible">
             {this.state.calendarRangeContextLabel}
           </div>
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar
-          ref={this.calendarRef}
           plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
           // Legacy contract marker: initialView="dayGridMonth"
           initialView={this.state.currentCalendarView}
+          buttonText={{
+            listYear: "Year",
+            listMonth: "Month",
+            listWeek: "Week",
+          }}
           headerToolbar={{
-            left: "prev,next today",
+            left: "prev,next today listYear,listWeek,listMonth",
             center: "title",
-            right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
+            right: "dayGridMonth,timeGridWeek,timeGridDay",
           }}
           events={events}
           selectable={true}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -984,6 +984,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const isCalendarLoading = this.state.calendarLoadState === "loading";
     const isCalendarEmpty = this.state.calendarLoadState === "empty";
     const hasCalendarError = this.state.calendarLoadState === "error";
+    const isListView = this.state.currentCalendarView.startsWith("list");
 
     const allEvents = this.state.items.map((item) => ({
       id: item.Id,
@@ -1008,38 +1009,40 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          <div className="calendar-agenda-range-controls" data-calendar-range-controls="visible">
-            <span className="calendar-agenda-range-label">Agenda range:</span>
-            <input type="date" className="summit-form-input" value={this.state.agendaRangeStart} onChange={this.handleAgendaRangeStartChange} aria-label="Agenda range start date" />
-            <span className="calendar-agenda-range-separator">to</span>
-            <input type="date" className="summit-form-input" value={this.state.agendaRangeEnd} onChange={this.handleAgendaRangeEndChange} aria-label="Agenda range end date" />
-            <button type="button" className="summit-button summit-button-secondary" onClick={this.applyCustomAgendaRange}>
-              Apply
-            </button>
-            <div className="calendar-agenda-presets" role="group" aria-label="Agenda quick select">
-              <button
-                type="button"
-                className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "week" ? "calendar-agenda-preset-active" : ""}`}
-                onClick={() => this.handleAgendaPresetSelect("week")}
-              >
-                Week
+          {isListView && (
+            <div className="calendar-agenda-range-controls" data-calendar-range-controls="visible">
+              <span className="calendar-agenda-range-label">List range:</span>
+              <input type="date" className="summit-form-input" value={this.state.agendaRangeStart} onChange={this.handleAgendaRangeStartChange} aria-label="List range start date" />
+              <span className="calendar-agenda-range-separator">to</span>
+              <input type="date" className="summit-form-input" value={this.state.agendaRangeEnd} onChange={this.handleAgendaRangeEndChange} aria-label="List range end date" />
+              <button type="button" className="summit-button summit-button-secondary" onClick={this.applyCustomAgendaRange}>
+                Apply
               </button>
-              <button
-                type="button"
-                className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "month" ? "calendar-agenda-preset-active" : ""}`}
-                onClick={() => this.handleAgendaPresetSelect("month")}
-              >
-                Month
-              </button>
-              <button
-                type="button"
-                className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "year" ? "calendar-agenda-preset-active" : ""}`}
-                onClick={() => this.handleAgendaPresetSelect("year")}
-              >
-                Year
-              </button>
+              <div className="calendar-agenda-presets" role="group" aria-label="List quick select">
+                <button
+                  type="button"
+                  className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "week" ? "calendar-agenda-preset-active" : ""}`}
+                  onClick={() => this.handleAgendaPresetSelect("week")}
+                >
+                  Week
+                </button>
+                <button
+                  type="button"
+                  className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "month" ? "calendar-agenda-preset-active" : ""}`}
+                  onClick={() => this.handleAgendaPresetSelect("month")}
+                >
+                  Month
+                </button>
+                <button
+                  type="button"
+                  className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "year" ? "calendar-agenda-preset-active" : ""}`}
+                  onClick={() => this.handleAgendaPresetSelect("year")}
+                >
+                  Year
+                </button>
+              </div>
             </div>
-          </div>
+          )}
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar
@@ -1054,7 +1057,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
             dayGridMonth: "Month",
             timeGridWeek: "Week",
             timeGridDay: "Day",
-            listRange: "Agenda",
+            listRange: "List",
           }}
           headerToolbar={{
             left: "prev,next today",

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -954,7 +954,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
                 aria-pressed={this.state.calendarQuickFilter === "next7days"}
                 onClick={() => this.setCalendarQuickFilter("next7days")}
               >
-                Next 7 days
+                Week
               </button>
               <button
                 type="button"
@@ -963,7 +963,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
                 aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
                 onClick={() => this.setCalendarQuickFilter("thisMonth")}
               >
-                This month
+                Month
               </button>
             </div>
           )}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -100,8 +100,6 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       }
 
       const persistedView = window.localStorage.getItem(SUMMIT_CALENDAR_VIEW_STORAGE_KEY);
-      // listRange is now only used for custom date ranges, not as a persisted view
-      if (persistedView === "listRange") return "listWeek";
       return persistedView || fallbackView;
     } catch {
       return fallbackView;
@@ -112,6 +110,10 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     try {
       if (typeof window === "undefined" || !window.localStorage) {
         return;
+      }
+
+      if (viewType === "listRange") {
+        viewType = "listWeek";
       }
 
       localStorage.setItem(SUMMIT_CALENDAR_VIEW_STORAGE_KEY, viewType);

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -919,8 +919,14 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         item,
       },
     }));
-    const filteredItems = this.state.items.filter((item) => this.applyCalendarQuickFilter(item));
-    const events = allEvents.filter((event) => this.applyCalendarQuickFilter(event.extendedProps.item));
+    // Only apply quick filter when in list view
+    const isListView = this.state.currentCalendarView === "listWeek";
+    const filteredItems = isListView
+      ? this.state.items.filter((item) => this.applyCalendarQuickFilter(item))
+      : this.state.items;
+    const events = isListView
+      ? allEvents.filter((event) => this.applyCalendarQuickFilter(event.extendedProps.item))
+      : allEvents;
 
     return (
       <div id="scheduler" style={{ width: "100%", height: "100%" }} onKeyDown={this.handleSchedulerKeyDown} tabIndex={0} data-calendar-shortcuts="new-event">
@@ -930,17 +936,19 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
-            <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="all" onClick={() => this.setCalendarQuickFilter("all")}>
-              All
-            </button>
-            <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="next7days" onClick={() => this.setCalendarQuickFilter("next7days")}>
-              Next 7 days
-            </button>
-            <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="thisMonth" onClick={() => this.setCalendarQuickFilter("thisMonth")}>
-              This month
-            </button>
-          </div>
+          {this.state.currentCalendarView === "listWeek" && (
+            <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
+              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="all" onClick={() => this.setCalendarQuickFilter("all")}>
+                All
+              </button>
+              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="next7days" onClick={() => this.setCalendarQuickFilter("next7days")}>
+                Next 7 days
+              </button>
+              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="thisMonth" onClick={() => this.setCalendarQuickFilter("thisMonth")}>
+                This month
+              </button>
+            </div>
+          )}
           <div className="calendar-range-context" data-calendar-range-context="visible">
             {this.state.calendarRangeContextLabel}
           </div>

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -57,6 +57,8 @@ interface SummitCalendarState {
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
+  private calendarRef = React.createRef<FullCalendar>();
+
   constructor(props: SummitCalendarProps) {
     super(props);
     this.state = {
@@ -112,7 +114,27 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
   };
 
   setCalendarQuickFilter = (calendarQuickFilter: CalendarQuickFilter) => {
-    this.setState({ calendarQuickFilter });
+    this.setState({ calendarQuickFilter }, () => {
+      const calendarApi = this.calendarRef.current?.getApi();
+      if (!calendarApi) {
+        return;
+      }
+
+      switch (calendarQuickFilter) {
+        case "next7days":
+          calendarApi.changeView("listWeek", moment().toDate());
+          break;
+        case "thisMonth":
+          calendarApi.changeView("listMonth", moment().startOf("month").toDate());
+          break;
+        case "all":
+        default:
+          if (this.state.currentCalendarView.startsWith("list")) {
+            calendarApi.changeView("listWeek", moment().toDate());
+          }
+          break;
+      }
+    });
   };
 
   applyCalendarQuickFilter = (item: SummitCalendarItem): boolean => {
@@ -268,7 +290,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
 
     this.persistCalendarView(args.view.type);
-    const preserveListFilter = this.state.currentCalendarView === "listWeek" && args.view.type === "listWeek";
+    const preserveListFilter = this.state.currentCalendarView.startsWith("list") && args.view.type.startsWith("list");
     const calendarQuickFilter = preserveListFilter ? this.state.calendarQuickFilter : "all";
     this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel, calendarQuickFilter }, () => {
       this.fetchData(startDate, endDate);
@@ -922,7 +944,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       },
     }));
     // Only apply quick filter when in list view
-    const isListView = this.state.currentCalendarView === "listWeek";
+    const isListView = this.state.currentCalendarView.startsWith("list");
     const filteredItems = isListView
       ? this.state.items.filter((item) => this.applyCalendarQuickFilter(item))
       : this.state.items;
@@ -938,7 +960,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
-          {this.state.currentCalendarView === "listWeek" && (
+          {isListView && (
             <div className="calendar-quick-filters fc fc-button-group" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
@@ -975,6 +997,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar
+          ref={this.calendarRef}
           plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
           // Legacy contract marker: initialView="dayGridMonth"
           initialView={this.state.currentCalendarView}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -942,7 +942,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
             <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
-                className={`summit-button ${this.state.calendarQuickFilter === "all" ? "summit-button-primary" : "summit-button-secondary"}`}
+                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}
                 data-calendar-quick-filter="all"
                 aria-pressed={this.state.calendarQuickFilter === "all"}
                 onClick={() => this.setCalendarQuickFilter("all")}
@@ -951,7 +951,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
               </button>
               <button
                 type="button"
-                className={`summit-button ${this.state.calendarQuickFilter === "next7days" ? "summit-button-primary" : "summit-button-secondary"}`}
+                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "next7days" ? "fc-button-active" : ""}`}
                 data-calendar-quick-filter="next7days"
                 aria-pressed={this.state.calendarQuickFilter === "next7days"}
                 onClick={() => this.setCalendarQuickFilter("next7days")}
@@ -960,7 +960,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
               </button>
               <button
                 type="button"
-                className={`summit-button ${this.state.calendarQuickFilter === "thisMonth" ? "summit-button-primary" : "summit-button-secondary"}`}
+                className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "thisMonth" ? "fc-button-active" : ""}`}
                 data-calendar-quick-filter="thisMonth"
                 aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
                 onClick={() => this.setCalendarQuickFilter("thisMonth")}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -26,6 +26,7 @@ import { DropDownListComponent } from "@/components/SimpleDropdown";
 import { DialogComponent, DialogUtility } from "@/components/DialogComponent";
 
 const SUMMIT_CALENDAR_VIEW_STORAGE_KEY = "summit.calendar.currentView";
+type AgendaRangePreset = "week" | "month" | "year" | "custom";
 
 interface SummitCalendarProps {
   items: SummitCalendarItem[];
@@ -51,9 +52,14 @@ interface SummitCalendarState {
   editorValidationErrors: Record<string, string>;
   editorSoftConflictWarnings: string[];
   currentCalendarView: string;
+  agendaRangeStart: string;
+  agendaRangeEnd: string;
+  agendaRangePreset: AgendaRangePreset;
 }
 
 export class SummitCalendarComponent extends React.Component<SummitCalendarProps, SummitCalendarState> {
+  private calendarRef = React.createRef<FullCalendar>();
+
   constructor(props: SummitCalendarProps) {
     super(props);
     this.state = {
@@ -75,6 +81,9 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       editorValidationErrors: {},
       editorSoftConflictWarnings: [],
       currentCalendarView: this.loadPersistedCalendarView(),
+      agendaRangeStart: moment().startOf("week").format("YYYY-MM-DD"),
+      agendaRangeEnd: moment().startOf("week").add(6, "days").format("YYYY-MM-DD"),
+      agendaRangePreset: "week",
     };
     this.handleInputChange = this.handleInputChange.bind(this);
   }
@@ -88,6 +97,10 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       }
 
       const persistedView = window.localStorage.getItem(SUMMIT_CALENDAR_VIEW_STORAGE_KEY);
+      if (persistedView === "listWeek" || persistedView === "listMonth" || persistedView === "listYear") {
+        return "listRange";
+      }
+
       return persistedView || fallbackView;
     } catch {
       return fallbackView;
@@ -239,22 +252,114 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
   handleDatesSet = (args: DatesSetArg) => {
     const startDate = moment(args.start).format("YYYY-MM-DDTHH:mm:ss");
     const endDate = moment(args.end).format("YYYY-MM-DDTHH:mm:ss");
+    const agendaRangeStart = moment(args.start).format("YYYY-MM-DD");
+    const agendaRangeEnd = moment(args.end).subtract(1, "day").format("YYYY-MM-DD");
+    const agendaRangePreset = this.getAgendaRangePreset(args.view.type, args.start, args.end);
     this.persistCalendarView(args.view.type);
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type }, () => {
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, agendaRangeStart, agendaRangeEnd, agendaRangePreset }, () => {
       this.fetchData(startDate, endDate);
     });
   };
 
+  getAgendaRangePreset = (viewType: string, start: Date, endExclusive: Date): AgendaRangePreset => {
+    if (viewType !== "listRange") {
+      return "custom";
+    }
+
+    const startMoment = moment(start).startOf("day");
+    const endMoment = moment(endExclusive).startOf("day");
+
+    if (startMoment.clone().add(7, "days").isSame(endMoment)) {
+      return "week";
+    }
+
+    if (startMoment.date() === 1 && startMoment.clone().add(1, "month").isSame(endMoment)) {
+      return "month";
+    }
+
+    if (startMoment.dayOfYear() === 1 && startMoment.clone().add(1, "year").isSame(endMoment)) {
+      return "year";
+    }
+
+    return "custom";
+  };
+
+  handleAgendaPresetSelect = (preset: Exclude<AgendaRangePreset, "custom">) => {
+    const calendarApi = this.calendarRef.current?.getApi();
+    if (!calendarApi) {
+      return;
+    }
+
+    const anchor = this.state.agendaRangeStart ? moment(this.state.agendaRangeStart, "YYYY-MM-DD") : moment();
+    let start = anchor.clone().startOf("week");
+    let endExclusive = start.clone().add(7, "days");
+
+    if (preset === "month") {
+      start = anchor.clone().startOf("month");
+      endExclusive = start.clone().add(1, "month");
+    } else if (preset === "year") {
+      start = anchor.clone().startOf("year");
+      endExclusive = start.clone().add(1, "year");
+    }
+
+    this.setState(
+      {
+        agendaRangeStart: start.format("YYYY-MM-DD"),
+        agendaRangeEnd: endExclusive.clone().subtract(1, "day").format("YYYY-MM-DD"),
+        agendaRangePreset: preset,
+      },
+      () => {
+        calendarApi.changeView("listRange", { start: start.toDate(), end: endExclusive.toDate() });
+      },
+    );
+  };
+
+  handleAgendaRangeStartChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ agendaRangeStart: event.target.value, agendaRangePreset: "custom" });
+  };
+
+  handleAgendaRangeEndChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ agendaRangeEnd: event.target.value, agendaRangePreset: "custom" });
+  };
+
+  applyCustomAgendaRange = () => {
+    const calendarApi = this.calendarRef.current?.getApi();
+    if (!calendarApi) {
+      return;
+    }
+
+    const start = moment(this.state.agendaRangeStart, "YYYY-MM-DD", true);
+    const endInclusive = moment(this.state.agendaRangeEnd, "YYYY-MM-DD", true);
+    if (!start.isValid() || !endInclusive.isValid() || endInclusive.isBefore(start)) {
+      return;
+    }
+
+    const endExclusive = endInclusive.clone().add(1, "day");
+    this.setState({ agendaRangePreset: "custom" }, () => {
+      calendarApi.changeView("listRange", { start: start.toDate(), end: endExclusive.toDate() });
+    });
+  };
+
   renderCalendarLegend = (items: SummitCalendarItem[]) => {
-    const uniqueColours = Array.from(new Set(items.map((item) => item.color).filter(Boolean)));
+    const seen = new Set<string>();
+    const entries: { color: string; label: string }[] = [];
+    for (const item of items) {
+      if (!item.color) continue;
+      const label = item.event.invitee_name || item.event.section;
+      const key = `${item.color}|${label}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        entries.push({ color: item.color, label });
+      }
+    }
 
     return (
       <div className="calendar-legend" data-calendar-legend="visible" aria-label="Calendar legend">
         <span>Legend:</span>
-        {uniqueColours.map((color, index) => (
-          <span key={`legend-${color}-${index}`} className="calendar-legend-item">
+        {entries.map(({ color, label }) => (
+          <span key={`legend-${color}-${label}`} className="calendar-legend-item">
             <span className="calendar-legend-swatch" style={{ backgroundColor: color }} />
-            <span>Event colour {index + 1}</span>
+            <span>{label}</span>
           </span>
         ))}
       </div>
@@ -903,21 +1008,58 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           <span id="calendar-error-state" data-active={String(hasCalendarError)} />
         </div>
         <div className="calendar-ux-toolbar">
+          <div className="calendar-agenda-range-controls" data-calendar-range-controls="visible">
+            <span className="calendar-agenda-range-label">Agenda range:</span>
+            <input type="date" className="summit-form-input" value={this.state.agendaRangeStart} onChange={this.handleAgendaRangeStartChange} aria-label="Agenda range start date" />
+            <span className="calendar-agenda-range-separator">to</span>
+            <input type="date" className="summit-form-input" value={this.state.agendaRangeEnd} onChange={this.handleAgendaRangeEndChange} aria-label="Agenda range end date" />
+            <button type="button" className="summit-button summit-button-secondary" onClick={this.applyCustomAgendaRange}>
+              Apply
+            </button>
+            <div className="calendar-agenda-presets" role="group" aria-label="Agenda quick select">
+              <button
+                type="button"
+                className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "week" ? "calendar-agenda-preset-active" : ""}`}
+                onClick={() => this.handleAgendaPresetSelect("week")}
+              >
+                Week
+              </button>
+              <button
+                type="button"
+                className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "month" ? "calendar-agenda-preset-active" : ""}`}
+                onClick={() => this.handleAgendaPresetSelect("month")}
+              >
+                Month
+              </button>
+              <button
+                type="button"
+                className={`summit-button summit-button-secondary ${this.state.agendaRangePreset === "year" ? "calendar-agenda-preset-active" : ""}`}
+                onClick={() => this.handleAgendaPresetSelect("year")}
+              >
+                Year
+              </button>
+            </div>
+          </div>
           {this.renderCalendarLegend(filteredItems)}
         </div>
         <FullCalendar
+          ref={this.calendarRef}
           plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
           // Legacy contract marker: initialView="dayGridMonth"
           initialView={this.state.currentCalendarView}
+          views={{
+            listRange: { type: "list", buttonText: "Agenda" },
+          }}
           buttonText={{
-            listYear: "Year",
-            listMonth: "Month",
-            listWeek: "Week",
+            dayGridMonth: "Month",
+            timeGridWeek: "Week",
+            timeGridDay: "Day",
+            listRange: "Agenda",
           }}
           headerToolbar={{
-            left: "prev,next today listYear,listWeek,listMonth",
+            left: "prev,next today",
             center: "title",
-            right: "dayGridMonth,timeGridWeek,timeGridDay",
+            right: "dayGridMonth,timeGridWeek,timeGridDay,listRange",
           }}
           events={events}
           selectable={true}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -939,7 +939,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         </div>
         <div className="calendar-ux-toolbar">
           {this.state.currentCalendarView === "listWeek" && (
-            <div className="calendar-quick-filters fc" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
+            <div className="calendar-quick-filters fc fc-button-group" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
               <button
                 type="button"
                 className={`fc-button fc-button-primary ${this.state.calendarQuickFilter === "all" ? "fc-button-active" : ""}`}

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -1,5 +1,6 @@
 import React, { FocusEvent } from "react";
 import FullCalendar from "@fullcalendar/react";
+import enAuLocale from "@fullcalendar/core/locales/en-au";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import listPlugin from "@fullcalendar/list";
@@ -1061,6 +1062,7 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
           eventClick={this.handleEventClick}
           datesSet={this.handleDatesSet}
           eventDidMount={this.eventDidMount}
+          locale={enAuLocale}
           height={"auto"}
         />
         <DialogComponent

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -268,7 +268,9 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
     const calendarRangeContextLabel = `Current range: ${moment(args.start).format("D MMM YYYY")} - ${moment(args.end).subtract(1, "day").format("D MMM YYYY")}`;
 
     this.persistCalendarView(args.view.type);
-    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel }, () => {
+    const preserveListFilter = this.state.currentCalendarView === "listWeek" && args.view.type === "listWeek";
+    const calendarQuickFilter = preserveListFilter ? this.state.calendarQuickFilter : "all";
+    this.setState({ currentWindow: { startDate, endDate }, currentCalendarView: args.view.type, calendarRangeContextLabel, calendarQuickFilter }, () => {
       this.fetchData(startDate, endDate);
     });
   };
@@ -938,13 +940,31 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
         <div className="calendar-ux-toolbar">
           {this.state.currentCalendarView === "listWeek" && (
             <div className="calendar-quick-filters" data-calendar-quick-filters="enabled" role="group" aria-label="Quick calendar filters">
-              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="all" onClick={() => this.setCalendarQuickFilter("all")}>
+              <button
+                type="button"
+                className={`summit-button ${this.state.calendarQuickFilter === "all" ? "summit-button-primary" : "summit-button-secondary"}`}
+                data-calendar-quick-filter="all"
+                aria-pressed={this.state.calendarQuickFilter === "all"}
+                onClick={() => this.setCalendarQuickFilter("all")}
+              >
                 All
               </button>
-              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="next7days" onClick={() => this.setCalendarQuickFilter("next7days")}>
+              <button
+                type="button"
+                className={`summit-button ${this.state.calendarQuickFilter === "next7days" ? "summit-button-primary" : "summit-button-secondary"}`}
+                data-calendar-quick-filter="next7days"
+                aria-pressed={this.state.calendarQuickFilter === "next7days"}
+                onClick={() => this.setCalendarQuickFilter("next7days")}
+              >
                 Next 7 days
               </button>
-              <button type="button" className="summit-button summit-button-secondary" data-calendar-quick-filter="thisMonth" onClick={() => this.setCalendarQuickFilter("thisMonth")}>
+              <button
+                type="button"
+                className={`summit-button ${this.state.calendarQuickFilter === "thisMonth" ? "summit-button-primary" : "summit-button-secondary"}`}
+                data-calendar-quick-filter="thisMonth"
+                aria-pressed={this.state.calendarQuickFilter === "thisMonth"}
+                onClick={() => this.setCalendarQuickFilter("thisMonth")}
+              >
                 This month
               </button>
             </div>

--- a/src/pages/SummitCalendar/components/SummitCalendar.tsx
+++ b/src/pages/SummitCalendar/components/SummitCalendar.tsx
@@ -99,10 +99,8 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       }
 
       const persistedView = window.localStorage.getItem(SUMMIT_CALENDAR_VIEW_STORAGE_KEY);
-      if (persistedView === "listWeek" || persistedView === "listMonth" || persistedView === "listYear") {
-        return "listRange";
-      }
-
+      // listRange is now only used for custom date ranges, not as a persisted view
+      if (persistedView === "listRange") return "listWeek";
       return persistedView || fallbackView;
     } catch {
       return fallbackView;
@@ -264,24 +262,18 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
   };
 
   getAgendaRangePreset = (viewType: string, start: Date, endExclusive: Date): AgendaRangePreset => {
-    if (viewType !== "listRange") {
-      return "custom";
-    }
+    if (viewType === "listWeek") return "week";
+    if (viewType === "listMonth") return "month";
+    if (viewType === "listYear") return "year";
+    if (viewType !== "listRange") return "custom";
 
+    // listRange — detect by range length
     const startMoment = moment(start).startOf("day");
     const endMoment = moment(endExclusive).startOf("day");
 
-    if (startMoment.clone().add(7, "days").isSame(endMoment)) {
-      return "week";
-    }
-
-    if (startMoment.date() === 1 && startMoment.clone().add(1, "month").isSame(endMoment)) {
-      return "month";
-    }
-
-    if (startMoment.dayOfYear() === 1 && startMoment.clone().add(1, "year").isSame(endMoment)) {
-      return "year";
-    }
+    if (startMoment.clone().add(7, "days").isSame(endMoment)) return "week";
+    if (startMoment.date() === 1 && startMoment.clone().add(1, "month").isSame(endMoment)) return "month";
+    if (startMoment.dayOfYear() === 1 && startMoment.clone().add(1, "year").isSame(endMoment)) return "year";
 
     return "custom";
   };
@@ -292,28 +284,11 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
       return;
     }
 
-    const anchor = this.state.agendaRangeStart ? moment(this.state.agendaRangeStart, "YYYY-MM-DD") : moment();
-    let start = anchor.clone().startOf("week");
-    let endExclusive = start.clone().add(7, "days");
-
-    if (preset === "month") {
-      start = anchor.clone().startOf("month");
-      endExclusive = start.clone().add(1, "month");
-    } else if (preset === "year") {
-      start = anchor.clone().startOf("year");
-      endExclusive = start.clone().add(1, "year");
-    }
-
-    this.setState(
-      {
-        agendaRangeStart: start.format("YYYY-MM-DD"),
-        agendaRangeEnd: endExclusive.clone().subtract(1, "day").format("YYYY-MM-DD"),
-        agendaRangePreset: preset,
-      },
-      () => {
-        calendarApi.changeView("listRange", { start: start.toDate(), end: endExclusive.toDate() });
-      },
-    );
+    // Use built-in list views so prev/next/today navigation works natively.
+    const viewName = preset === "week" ? "listWeek" : preset === "month" ? "listMonth" : "listYear";
+    this.setState({ agendaRangePreset: preset }, () => {
+      calendarApi.changeView(viewName);
+    });
   };
 
   handleListRangePickerChange = (dates: [Date | null, Date | null]) => {
@@ -1073,12 +1048,12 @@ export class SummitCalendarComponent extends React.Component<SummitCalendarProps
             dayGridMonth: "Month",
             timeGridWeek: "Week",
             timeGridDay: "Day",
-            listRange: "List",
+            listWeek: "List",
           }}
           headerToolbar={{
             left: "prev,next today",
             center: "title",
-            right: "dayGridMonth,timeGridWeek,timeGridDay,listRange",
+            right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
           }}
           events={events}
           selectable={true}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -206,11 +206,18 @@
   gap: 8px;
 }
 
+.calendar-quick-filters.fc {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
 .calendar-quick-filters.fc .fc-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: auto;
+  white-space: nowrap;
   margin: 0;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -214,13 +214,13 @@
   color: var(--summit-color-text-primary);
 }
 
-.calendar-agenda-range-separator {
-  color: var(--summit-color-text-secondary);
-  font-size: var(--summit-font-size-sm);
-}
-
 .calendar-agenda-range-controls .summit-form-input {
   width: auto;
+}
+
+.calendar-agenda-range-controls .react-datepicker-wrapper,
+.calendar-agenda-range-controls .react-datepicker__input-container {
+  display: inline-flex;
 }
 
 .calendar-agenda-presets {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -221,7 +221,7 @@
 .calendar-agenda-range-controls .react-datepicker-wrapper,
 .calendar-agenda-range-controls .react-datepicker__input-container {
   display: inline-flex;
-  width: auto;
+  width: 210px;
 }
 
 .calendar-agenda-presets {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -207,18 +207,22 @@
 }
 
 .calendar-quick-filters.fc {
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: nowrap;
+  display: inline-flex !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
+  flex-direction: row !important;
 }
 
 .calendar-quick-filters.fc .fc-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: auto;
-  white-space: nowrap;
-  margin: 0;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: auto !important;
+  min-width: unset !important;
+  white-space: nowrap !important;
+  margin: 0 !important;
+  float: none !important;
+  flex: 0 0 auto !important;
 }
 
 .calendar-range-context {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -201,30 +201,6 @@
   margin: var(--summit-space-md) 0;
 }
 
-.calendar-quick-filters {
-  display: inline-flex;
-  gap: 8px;
-}
-
-.calendar-quick-filters.fc {
-  display: inline-flex !important;
-  align-items: center !important;
-  flex-wrap: nowrap !important;
-  flex-direction: row !important;
-}
-
-.calendar-quick-filters.fc .fc-button {
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  width: auto !important;
-  min-width: unset !important;
-  white-space: nowrap !important;
-  margin: 0 !important;
-  float: none !important;
-  flex: 0 0 auto !important;
-}
-
 .calendar-range-context {
   font-weight: var(--summit-font-weight-semibold);
   color: var(--summit-color-bg-primary);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -201,6 +201,40 @@
   margin: var(--summit-space-md) 0;
 }
 
+.calendar-agenda-range-controls {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--summit-space-sm);
+  align-items: center;
+}
+
+.calendar-agenda-range-label {
+  font-size: var(--summit-font-size-sm);
+  font-weight: var(--summit-font-weight-semibold);
+  color: var(--summit-color-text-primary);
+}
+
+.calendar-agenda-range-separator {
+  color: var(--summit-color-text-secondary);
+  font-size: var(--summit-font-size-sm);
+}
+
+.calendar-agenda-range-controls .summit-form-input {
+  width: auto;
+}
+
+.calendar-agenda-presets {
+  display: inline-flex;
+  gap: var(--summit-space-xs);
+  align-items: center;
+}
+
+.calendar-agenda-preset-active {
+  background: var(--summit-color-bg-primary);
+  border-color: var(--summit-color-bg-primary);
+  color: var(--summit-color-text-on-primary);
+}
+
 .calendar-legend {
   display: inline-flex;
   gap: 10px;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -215,12 +215,13 @@
 }
 
 .calendar-agenda-range-controls .summit-form-input {
-  width: 180px;
+  width: 210px;
 }
 
 .calendar-agenda-range-controls .react-datepicker-wrapper,
 .calendar-agenda-range-controls .react-datepicker__input-container {
   display: inline-flex;
+  width: auto;
 }
 
 .calendar-agenda-presets {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -206,6 +206,14 @@
   gap: 8px;
 }
 
+.calendar-quick-filters.fc .fc-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  margin: 0;
+}
+
 .calendar-range-context {
   font-weight: var(--summit-font-weight-semibold);
   color: var(--summit-color-bg-primary);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -201,11 +201,6 @@
   margin: var(--summit-space-md) 0;
 }
 
-.calendar-range-context {
-  font-weight: var(--summit-font-weight-semibold);
-  color: var(--summit-color-bg-primary);
-}
-
 .calendar-legend {
   display: inline-flex;
   gap: 10px;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -230,9 +230,11 @@
 }
 
 .calendar-agenda-preset-active {
-  background: var(--summit-color-bg-primary);
+  background: transparent;
   border-color: var(--summit-color-bg-primary);
-  color: var(--summit-color-text-on-primary);
+  color: inherit;
+  outline: 2px solid var(--summit-color-bg-primary);
+  outline-offset: 1px;
 }
 
 .calendar-legend {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -215,7 +215,7 @@
 }
 
 .calendar-agenda-range-controls .summit-form-input {
-  width: auto;
+  width: 180px;
 }
 
 .calendar-agenda-range-controls .react-datepicker-wrapper,

--- a/tests/unit/components/calendar-legend-and-range-context.spec.ts
+++ b/tests/unit/components/calendar-legend-and-range-context.spec.ts
@@ -6,18 +6,26 @@ const SUMMIT_CALENDAR_PATH = path.resolve(REPO_ROOT, "src/pages/SummitCalendar/c
 const STYLES_PATH = path.resolve(REPO_ROOT, "src/styles/index.css");
 
 describe("Phase 3 calendar legend and range context", () => {
-  it("shows date-range context and an event colour legend with dedicated styling hooks", () => {
+  it("shows list-range styling hooks and labels legend entries by invitee/section", () => {
     const source = fs.readFileSync(SUMMIT_CALENDAR_PATH, "utf8");
     const css = fs.readFileSync(STYLES_PATH, "utf8");
 
-    expect(source).toContain("calendarRangeContextLabel");
-    expect(source).toContain('data-calendar-range-context="visible"');
+    expect(source).toContain("item.event.invitee_name || item.event.section");
+    expect(source).toContain("const key = `${item.color}|${label}`");
+    expect(source).toContain("entries.push({ color: item.color, label })");
+    expect(source).toContain("<span>{label}</span>");
     expect(source).toContain("renderCalendarLegend");
     expect(source).toContain('data-calendar-legend="visible"');
+    expect(source).toContain('data-calendar-range-controls="visible"');
     expect(source).toContain("calendar-legend-swatch");
+    expect(source).not.toContain('data-calendar-range-context="visible"');
 
     expect(css).toContain(".calendar-ux-toolbar");
-    expect(css).toContain(".calendar-range-context");
+    expect(css).toContain(".calendar-agenda-range-controls");
+    expect(css).toContain(".calendar-agenda-range-label");
+    expect(css).toContain(".calendar-agenda-presets");
+    expect(css).toContain(".calendar-agenda-preset-active");
+    expect(css).not.toContain(".calendar-range-context");
     expect(css).toContain(".calendar-legend");
     expect(css).toContain(".calendar-legend-swatch");
     expect(css).toContain(".calendar-selector-panel");

--- a/tests/unit/components/calendar-quick-filters.spec.ts
+++ b/tests/unit/components/calendar-quick-filters.spec.ts
@@ -5,15 +5,20 @@ const REPO_ROOT = path.resolve(__dirname, "../../..");
 const SUMMIT_CALENDAR_PATH = path.resolve(REPO_ROOT, "src/pages/SummitCalendar/components/SummitCalendar.tsx");
 
 describe("Phase 3 calendar quick filters", () => {
-  it("provides discoverable quick-filter controls and applies a selected filter to rendered events", () => {
+  it("provides list-range controls with presets and custom date-range handling for list views", () => {
     const source = fs.readFileSync(SUMMIT_CALENDAR_PATH, "utf8");
 
-    expect(source).toContain("calendarQuickFilter");
-    expect(source).toContain("setCalendarQuickFilter");
-    expect(source).toContain('data-calendar-quick-filters="enabled"');
-    expect(source).toContain('data-calendar-quick-filter="all"');
-    expect(source).toContain('data-calendar-quick-filter="next7days"');
-    expect(source).toContain('data-calendar-quick-filter="thisMonth"');
-    expect(source).toContain("applyCalendarQuickFilter");
+    expect(source).toContain("AgendaRangePreset");
+    expect(source).toContain("getAgendaRangePreset");
+    expect(source).toContain("handleAgendaPresetSelect");
+    expect(source).toContain("handleListRangePickerChange");
+
+    expect(source).toContain('data-calendar-range-controls="visible"');
+    expect(source).toContain('aria-label="List quick select"');
+    expect(source).toContain("calendarApi.changeView(viewName)");
+    expect(source).toContain('calendarApi.changeView("listRange"');
+
+    expect(source).not.toContain("calendarQuickFilter");
+    expect(source).not.toContain("applyCalendarQuickFilter");
   });
 });

--- a/tests/unit/components/calendar-view-persistence.spec.ts
+++ b/tests/unit/components/calendar-view-persistence.spec.ts
@@ -5,12 +5,14 @@ const REPO_ROOT = path.resolve(__dirname, "../../..");
 const SUMMIT_CALENDAR_PATH = path.resolve(REPO_ROOT, "src/pages/SummitCalendar/components/SummitCalendar.tsx");
 
 describe("Phase 3 calendar view persistence", () => {
-  it("persists and restores the selected FullCalendar view", () => {
+  it("persists and restores the selected FullCalendar view with listRange migration safeguards", () => {
     const source = fs.readFileSync(SUMMIT_CALENDAR_PATH, "utf8");
 
     expect(source).toContain("SUMMIT_CALENDAR_VIEW_STORAGE_KEY");
     expect(source).toContain("loadPersistedCalendarView");
     expect(source).toContain("persistCalendarView");
+    expect(source).toContain('if (viewType === "listRange")');
+    expect(source).toContain('viewType = "listWeek"');
     expect(source).toContain("args.view.type");
     expect(source).toContain("localStorage.setItem(SUMMIT_CALENDAR_VIEW_STORAGE_KEY");
     expect(source).toContain("initialView={this.state.currentCalendarView}");

--- a/tests/unit/components/calendar-view-switching.spec.ts
+++ b/tests/unit/components/calendar-view-switching.spec.ts
@@ -13,9 +13,13 @@ describe("Phase 5 calendar view switching contract", () => {
     expect(source).toContain("@fullcalendar/timegrid");
     expect(source).toContain("@fullcalendar/list");
     expect(source).toContain("@fullcalendar/interaction");
+    expect(source).toContain("@fullcalendar/core/locales/en-au");
 
     expect(source).toContain("headerToolbar");
     expect(source).toContain('initialView="dayGridMonth"');
+    expect(source).toContain("locale={enAuLocale}");
+    expect(source).toContain('listRange: { type: "list", buttonText: "Agenda" }');
+    expect(source).toContain("buttonText={");
     expect(source).toContain("dayGridMonth");
     expect(source).toContain("timeGridWeek");
     expect(source).toContain("timeGridDay");


### PR DESCRIPTION
Closes #149, #150

## Changes

### List view range controls
- Adds a toolbar above the calendar (visible only in list view) with a date range picker and Week / Month / Year quick-select preset buttons
- Preset buttons switch to the native \listWeek\ / \listMonth\ / \listYear\ FullCalendar views so prev / next / today navigation continues to work
- Custom date ranges from the picker use a \listRange\ view
- Preset button active state shown with an outline instead of a filled background

### Calendar legend
- Legend now shows the calendar / person name (\invitee_name\ or \section\) next to each colour swatch instead of generic labels

### en-AU locale
- FullCalendar locale set to \en-AU\ (Monday week start, Australian date formatting)

### Bug fixes
- Fixes #149 / #150: list range controls are scoped to list view only and do not globally filter events on other views