### PR TITLE
Improve Summit calendar event text readability (remove blue link colour and bold text)

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -290,6 +290,36 @@
   line-height: 1;
 }
 
+#scheduler .fc .fc-daygrid-event,
+#scheduler .fc .fc-daygrid-event .fc-event-time,
+#scheduler .fc .fc-daygrid-event .fc-event-title,
+#scheduler .fc .fc-timegrid-event,
+#scheduler .fc .fc-timegrid-event .fc-event-time,
+#scheduler .fc .fc-timegrid-event .fc-event-title {
+  font-weight: 400;
+}
+
+#scheduler .fc .fc-list-event-title a,
+#scheduler .fc .fc-list-event-time {
+  font-weight: 400;
+}
+
+#scheduler .fc .fc-daygrid-event,
+#scheduler .fc .fc-timegrid-event,
+#scheduler .fc .fc-list-event-title a {
+  color: #ffffff !important;
+}
+
+#scheduler .fc .fc-daygrid-event a,
+#scheduler .fc .fc-timegrid-event a,
+#scheduler .fc .fc-list-event-title a,
+#scheduler .fc .fc-list-event-time,
+#scheduler .fc .fc-event-time,
+#scheduler .fc .fc-event-title {
+  color: #ffffff !important;
+  text-decoration: none !important;
+}
+
 .data-grid-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fixes Summit Calendar event text readability issues by removing bold event text and preventing inherited global link blue in calendar event rows.

Updated calendar-scoped CSS in index.css so event/link text inside FullCalendar inherits intended event text color and no longer appears blue.